### PR TITLE
Fix input after Atari 7800 Proline/gamepad split

### DIFF
--- a/game.libretro.prosystem/addon.xml.in
+++ b/game.libretro.prosystem/addon.xml.in
@@ -5,7 +5,8 @@
 		provider-name="Libretro">
 	<requires>
 		<import addon="game.libretro" version="1.0.0"/>
-		<import addon="game.controller.atari.7800" version="1.0.0"/>
+		<import addon="game.controller.atari.7800.proline" version="1.0.0"/>
+		<import addon="game.controller.atari.7800.gamepad" version="1.0.0"/>
 	</requires>
 	<extension point="kodi.gameclient"
 			library_@PLATFORM@="@LIBRARY_FILENAME@">

--- a/game.libretro.prosystem/resources/buttonmap.xml
+++ b/game.libretro.prosystem/resources/buttonmap.xml
@@ -1,6 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <buttonmap version="2">
-    <controller id="game.controller.atari.7800" type="RETRO_DEVICE_JOYPAD" subclass="0">
+    <controller id="game.controller.atari.7800.proline" type="RETRO_DEVICE_JOYPAD" subclass="0">
+        <feature name="button1" mapto="RETRO_DEVICE_ID_JOYPAD_B"/>
+        <feature name="button2" mapto="RETRO_DEVICE_ID_JOYPAD_A"/>
+        <feature name="joystick" direction="up" mapto="RETRO_DEVICE_ID_JOYPAD_UP"/>
+        <feature name="joystick" direction="down" mapto="RETRO_DEVICE_ID_JOYPAD_DOWN"/>
+        <feature name="joystick" direction="right" mapto="RETRO_DEVICE_ID_JOYPAD_RIGHT"/>
+        <feature name="joystick" direction="left" mapto="RETRO_DEVICE_ID_JOYPAD_LEFT"/>
+        <feature name="reset" mapto="RETRO_DEVICE_ID_JOYPAD_X"/>
+        <feature name="select" mapto="RETRO_DEVICE_ID_JOYPAD_SELECT"/>
+        <feature name="pause" mapto="RETRO_DEVICE_ID_JOYPAD_START"/>
+        <feature name="leftdifficulty" mapto="RETRO_DEVICE_ID_JOYPAD_L"/>
+        <feature name="rightdifficulty" mapto="RETRO_DEVICE_ID_JOYPAD_R"/>
+    </controller>
+    <controller id="game.controller.atari.7800.gamepad" type="RETRO_DEVICE_JOYPAD" subclass="0">
         <feature name="button1" mapto="RETRO_DEVICE_ID_JOYPAD_B"/>
         <feature name="button2" mapto="RETRO_DEVICE_ID_JOYPAD_A"/>
         <feature name="joystick" direction="up" mapto="RETRO_DEVICE_ID_JOYPAD_UP"/>

--- a/game.libretro.prosystem/resources/buttonmap.xml
+++ b/game.libretro.prosystem/resources/buttonmap.xml
@@ -3,10 +3,10 @@
     <controller id="game.controller.atari.7800.proline" type="RETRO_DEVICE_JOYPAD" subclass="0">
         <feature name="button1" mapto="RETRO_DEVICE_ID_JOYPAD_B"/>
         <feature name="button2" mapto="RETRO_DEVICE_ID_JOYPAD_A"/>
-        <feature name="joystick" direction="up" mapto="RETRO_DEVICE_ID_JOYPAD_UP"/>
-        <feature name="joystick" direction="down" mapto="RETRO_DEVICE_ID_JOYPAD_DOWN"/>
-        <feature name="joystick" direction="right" mapto="RETRO_DEVICE_ID_JOYPAD_RIGHT"/>
-        <feature name="joystick" direction="left" mapto="RETRO_DEVICE_ID_JOYPAD_LEFT"/>
+        <feature name="up" mapto="RETRO_DEVICE_ID_JOYPAD_UP"/>
+        <feature name="right" mapto="RETRO_DEVICE_ID_JOYPAD_RIGHT"/>
+        <feature name="down" mapto="RETRO_DEVICE_ID_JOYPAD_DOWN"/>
+        <feature name="left" mapto="RETRO_DEVICE_ID_JOYPAD_LEFT"/>
         <feature name="reset" mapto="RETRO_DEVICE_ID_JOYPAD_X"/>
         <feature name="select" mapto="RETRO_DEVICE_ID_JOYPAD_SELECT"/>
         <feature name="pause" mapto="RETRO_DEVICE_ID_JOYPAD_START"/>
@@ -16,10 +16,10 @@
     <controller id="game.controller.atari.7800.gamepad" type="RETRO_DEVICE_JOYPAD" subclass="0">
         <feature name="button1" mapto="RETRO_DEVICE_ID_JOYPAD_B"/>
         <feature name="button2" mapto="RETRO_DEVICE_ID_JOYPAD_A"/>
-        <feature name="joystick" direction="up" mapto="RETRO_DEVICE_ID_JOYPAD_UP"/>
-        <feature name="joystick" direction="down" mapto="RETRO_DEVICE_ID_JOYPAD_DOWN"/>
-        <feature name="joystick" direction="right" mapto="RETRO_DEVICE_ID_JOYPAD_RIGHT"/>
-        <feature name="joystick" direction="left" mapto="RETRO_DEVICE_ID_JOYPAD_LEFT"/>
+        <feature name="up" mapto="RETRO_DEVICE_ID_JOYPAD_UP"/>
+        <feature name="right" mapto="RETRO_DEVICE_ID_JOYPAD_RIGHT"/>
+        <feature name="down" mapto="RETRO_DEVICE_ID_JOYPAD_DOWN"/>
+        <feature name="left" mapto="RETRO_DEVICE_ID_JOYPAD_LEFT"/>
         <feature name="reset" mapto="RETRO_DEVICE_ID_JOYPAD_X"/>
         <feature name="select" mapto="RETRO_DEVICE_ID_JOYPAD_SELECT"/>
         <feature name="pause" mapto="RETRO_DEVICE_ID_JOYPAD_START"/>

--- a/game.libretro.prosystem/resources/topology.xml
+++ b/game.libretro.prosystem/resources/topology.xml
@@ -1,9 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <logicaltopology>
   <port type="controller" id="1">
-    <accepts controller="game.controller.atari.7800"/>
+    <accepts controller="game.controller.atari.7800.proline"/>
+    <accepts controller="game.controller.atari.7800.gamepad"/>
   </port>
   <port type="controller" id="2">
-    <accepts controller="game.controller.atari.7800"/>
+    <accepts controller="game.controller.atari.7800.proline"/>
+    <accepts controller="game.controller.atari.7800.gamepad"/>
   </port>
 </logicaltopology>


### PR DESCRIPTION
This fixes broken input after the Atari 7800 proline and gamepad controllers were split up.

Requires https://github.com/kodi-game/controller-topology-project/pull/25.